### PR TITLE
Completed the basic implementation of multilingual support

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -109,7 +109,8 @@ def enableProguardInReleaseBuilds = false
  * give correct results when using with locales other than en-US.  Note that
  * this variant is about 6MiB larger per architecture than default.
  */
-def jscFlavor = 'org.webkit:android-jsc:+'
+/*def jscFlavor = 'org.webkit:android-jsc:+'*/
+def jscFlavor = 'org.webkit:android-jsc-intl:+'
 
 /**
  * Whether to enable the Hermes VM.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -300,6 +300,8 @@ PODS:
     - React
   - RNGestureHandler (1.6.1):
     - React
+  - RNLocalize (1.3.4):
+    - React
   - RNReanimated (1.7.1):
     - React
   - RNScreens (2.4.0):
@@ -345,6 +347,7 @@ DEPENDENCIES:
   - ReactNativeDarkMode (from `../node_modules/react-native-dark-mode`)
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
+  - RNLocalize (from `../node_modules/react-native-localize`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -421,6 +424,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/masked-view"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
+  RNLocalize:
+    :path: "../node_modules/react-native-localize"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -468,6 +473,7 @@ SPEC CHECKSUMS:
   ReactNativeDarkMode: 0178ffca3b10f6a7c9f49d6f9810232b328fa949
   RNCMaskedView: 76c40a1d41c3e2535df09246a2b5487f04de0814
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
+  RNLocalize: 215c419a17d7585eb7a63c748ebfd042e0cb2c3d
   RNReanimated: 4e102df74a9674fa943e05f97f3362b6e44d0b48
   RNScreens: b5c0e1b2b04512919e78bd3898e144a157ce2363
   Yoga: 9db9ff2025ad21d1ac0a8b3c85d5ac4e7c29d525

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "@react-navigation/native": "^5.1.3",
     "@react-navigation/stack": "^5.2.9",
     "@types/node": "^13.9.8",
+    "intl": "^1.2.5",
     "react": "16.11.0",
+    "react-intl": "^4.3.1",
     "react-native": "0.62.0",
     "react-native-dark-mode": "^0.2.2",
     "react-native-gesture-handler": "^1.6.1",
+    "react-native-localize": "^1.3.4",
     "react-native-reanimated": "^1.7.1",
     "react-native-safe-area-context": "^0.7.3",
     "react-native-screens": "^2.4.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,37 @@
-import React from 'react'
-import {View, Image} from 'react-native'
+import React, {useEffect} from 'react'
 import {NavigationContainer} from '@react-navigation/native'
 import {createStackNavigator} from '@react-navigation/stack'
-
 import {useDarkMode} from 'react-native-dark-mode'
+import {IntlProvider} from 'react-intl'
+import useLocaleMessages from './effects/use-locale-messages.effect'
 
-import {iconSplash, containerStyles, colors} from './styles'
+import {colors} from './styles'
+
+import SCREENS from './constants/screens'
+import LaunchScreen from './screens/LaunchScreen'
+import SplashScreen from './screens/SplashScreen'
+
+import {forFade} from './navigation/interpolators'
 
 const Stack = createStackNavigator()
 
 export default function App() {
-  return <Navigation />
-}
+  const localeMessages = useLocaleMessages()
 
-function SplashScreen() {
+  useEffect(() => {
+    console.log(
+      'localeMessages changed >> ',
+      localeMessages.locale,
+      localeMessages.messages,
+    )
+  }, [localeMessages])
+
   return (
-    <View
-      style={[
-        containerStyles.fill,
-        containerStyles.centeredContent,
-        {backgroundColor: colors.Black},
-      ]}>
-      <Image source={iconSplash} />
-      <View />
-    </View>
+    <IntlProvider
+      locale={localeMessages.locale}
+      messages={localeMessages.messages}>
+      <Navigation />
+    </IntlProvider>
   )
 }
 
@@ -46,17 +54,32 @@ function Navigation() {
   return (
     <NavigationContainer ref={ref} theme={isDarkMode ? theme : theme}>
       <Stack.Navigator
-        initialRouteName="SplashScreen"
+        initialRouteName={SCREENS.LAUNCH}
         headerMode={'none'}
+        mode="modal"
         screenOptions={{
-          gestureEnabled: true,
+          gestureEnabled: false,
         }}>
+        <Stack.Screen name={SCREENS.LAUNCH} component={LaunchScreen} />
         <Stack.Screen
-          name="SplashScreen"
-          component={SplashScreen}
-          options={{title: 'BP Passport'}}
+          name={SCREENS.MAIN_STACK}
+          component={MainStack}
+          options={{cardStyleInterpolator: forFade}}
         />
       </Stack.Navigator>
     </NavigationContainer>
+  )
+}
+
+function MainStack() {
+  return (
+    <Stack.Navigator
+      initialRouteName={SCREENS.SPLASH}
+      headerMode={'none'}
+      screenOptions={{
+        gestureEnabled: true,
+      }}>
+      <Stack.Screen name={SCREENS.SPLASH} component={SplashScreen} />
+    </Stack.Navigator>
   )
 }

--- a/src/constants/screens.ts
+++ b/src/constants/screens.ts
@@ -1,0 +1,7 @@
+const SCREENS = {
+  LAUNCH: 'LaunchScreen',
+  MAIN_STACK: 'MainStack',
+  SPLASH: 'SplashScreen',
+}
+
+export default SCREENS

--- a/src/effects/use-locale-messages.effect.ts
+++ b/src/effects/use-locale-messages.effect.ts
@@ -1,0 +1,24 @@
+import React, {useEffect, useState} from 'react'
+import * as RNLocalize from 'react-native-localize'
+
+import en from '../translations/strings_en.json'
+import hi from '../translations/strings_hi_IN.json'
+import mr from '../translations/strings_mr_IN.json'
+import pa from '../translations/strings_pa_IN.json'
+
+const useLocaleMessages = () => {
+  const languages: {
+    [key: string]: any
+  } = {en, hi, mr, pa}
+
+  const availableTranslations = ['en', 'hi', 'mr', 'pa']
+  const [locale, setLocale] = useState(
+    RNLocalize.findBestAvailableLanguage(availableTranslations)?.languageTag ||
+      'en',
+  )
+  const [messages, setMessages] = useState(languages[locale])
+
+  return {locale, messages}
+}
+
+export default useLocaleMessages

--- a/src/navigation/interpolators.ts
+++ b/src/navigation/interpolators.ts
@@ -1,0 +1,9 @@
+import {StackCardInterpolationProps} from '@react-navigation/stack'
+
+const forFade = ({current}: StackCardInterpolationProps) => ({
+  cardStyle: {
+    opacity: current.progress,
+  },
+})
+
+export {forFade}

--- a/src/screens/LaunchScreen.tsx
+++ b/src/screens/LaunchScreen.tsx
@@ -1,0 +1,27 @@
+import React, {useEffect} from 'react'
+import {View, Image} from 'react-native'
+
+import {iconSplash, containerStyles, colors} from '../styles'
+import SCREENS from '../constants/screens'
+
+function LaunchScreen({navigation}: any) {
+  useEffect(() => {
+    setTimeout(() => {
+      navigation.replace(SCREENS.MAIN_STACK)
+    }, 2000)
+  }, [])
+
+  return (
+    <View
+      style={[
+        containerStyles.fill,
+        containerStyles.centeredContent,
+        {backgroundColor: colors.Black},
+      ]}>
+      <Image source={iconSplash} />
+      <View />
+    </View>
+  )
+}
+
+export default LaunchScreen

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import {View, Text} from 'react-native'
+import {FormattedMessage} from 'react-intl'
+
+import {containerStyles, colors} from '../styles'
+
+function SplashScreen({navigation}: any) {
+  return (
+    <View
+      style={[
+        containerStyles.fill,
+        containerStyles.centeredContent,
+        {backgroundColor: colors.White},
+      ]}>
+      <Text>
+        <FormattedMessage id="splash.title" />
+      </Text>
+      <Text>
+        <FormattedMessage id="splash.track" />
+      </Text>
+      <Text>
+        <FormattedMessage id="splash.talk" />
+      </Text>
+      <Text>
+        <FormattedMessage id="splash.reminders" />
+      </Text>
+      <View />
+    </View>
+  )
+}
+
+export default SplashScreen

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,5 +1,6 @@
 const colors = {
   Black: '#000000',
+  White: '#ffffff',
 }
 
 export default colors

--- a/src/translations/strings_en.json
+++ b/src/translations/strings_en.json
@@ -1,0 +1,7 @@
+{
+  "splash.title": "BP Passport",
+  "splash.track": "Track your blood pressure",
+  "splash.talk": "Talk to a real doctor about your BP",
+  "splash.reminders": "Reminders to take medicines",
+  "splash.next-button": "NEXT"
+}

--- a/src/translations/strings_hi_IN.json
+++ b/src/translations/strings_hi_IN.json
@@ -1,0 +1,7 @@
+{
+  "splash.title": "BP Passport - Hindi",
+  "splash.track": "Track your blood pressure",
+  "splash.talk": "Talk to a real doctor about your BP",
+  "splash.reminders": "Reminders to take medicines",
+  "splash.next-button": "NEXT"
+}

--- a/src/translations/strings_mr_IN.json
+++ b/src/translations/strings_mr_IN.json
@@ -1,0 +1,7 @@
+{
+  "splash.title": "BP Passport - Marathi",
+  "splash.track": "Track your blood pressure",
+  "splash.talk": "Talk to a real doctor about your BP",
+  "splash.reminders": "Reminders to take medicines",
+  "splash.next-button": "NEXT"
+}

--- a/src/translations/strings_pa_IN.json
+++ b/src/translations/strings_pa_IN.json
@@ -1,0 +1,7 @@
+{
+  "splash.title": "BP Passport - Punjabi",
+  "splash.track": "Track your blood pressure",
+  "splash.talk": "Talk to a real doctor about your BP",
+  "splash.reminders": "Reminders to take medicines",
+  "splash.next-button": "NEXT"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react",
     "lib": ["es6"],
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "noEmit": true,
     "strict": true,
     "target": "esnext"

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,6 +699,39 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
+"@formatjs/intl-displaynames@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-displaynames/-/intl-displaynames-1.2.2.tgz#d0f0edebad96660196d282f609a1169a88a27d4a"
+  integrity sha512-qwYxEWJEIplshOMWyLGl2g0d9g/25oQm8GWWCRcagHhv4YIfSJM5+GCTYNJiQImm10pKfEhoV5ezDs0Pr/8CRA==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.0"
+
+"@formatjs/intl-listformat@^1.4.2":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-1.4.3.tgz#3cb75b9a9da60ca54c52dd5a239a24cd448f7a60"
+  integrity sha512-FZcc3FSYYimMEm03+1qJzmsm1Vn5qxxkrFe0kqNKujEq3MAK+uL31jpPBiD1EPl22uTD0MHZMuZF55jqd/7R/w==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.1"
+
+"@formatjs/intl-relativetimeformat@^4.5.10":
+  version "4.5.11"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.11.tgz#8161aba04b3dd488a00e2642e007bf5359f8ad34"
+  integrity sha512-UdZtBISVHMB1n9dOldnNpEr90/qdHcOXe+EPBAy6pXsqKwL1Nh86PU5/2wJij1wl7lQDrCb2npcYnmScv4uGRg==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.1"
+
+"@formatjs/intl-unified-numberformat@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.0.tgz#0692346a9cd432abb2cd9b6879ddd6592585641a"
+  integrity sha512-wLT3myYq6fUhJYUh53tt5fMok+sUqO3Jy1XeSqYTphP7MmQl38tHqAIL65Dxh7M6/QlDEQTOkMZNpQcnT0AzaQ==
+  dependencies:
+    "@formatjs/intl-utils" "^2.2.0"
+
+"@formatjs/intl-utils@^2.2.0", "@formatjs/intl-utils@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.2.1.tgz#0eeefe92d317acfcd179c14826e719b3b130d82a"
+  integrity sha512-WF3oU6l2WqJjN4OWvnjF9AHyQjHpjcfpyuckM7euFeX6ZGRPpPj+ZCqzf41g81MSksf9aZI4fFCZXWTBusgcWA==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1164,6 +1197,19 @@
   version "2.0.36"
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.36.tgz#17ce0a235e9ffbcdcdf5095646b374c2bf615a4c"
   integrity sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ==
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
+"@types/invariant@^2.2.31":
+  version "2.2.31"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.31.tgz#4444c03004f215289dbca3856538434317dd28b2"
+  integrity sha512-jMlgg9pIURvy9jgBHCjQp/CyBjYHUwj91etVcDdXkFl2CwTFiQlB+8tcsMeXpXf2PFE5X2pjk4Gm43hQSMHAdA==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
@@ -3272,6 +3318,13 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -3420,6 +3473,31 @@ internal-slot@^1.0.2:
     es-abstract "^1.17.0-next.1"
     has "^1.0.3"
     side-channel "^1.0.2"
+
+intl-format-cache@^4.2.22:
+  version "4.2.23"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.2.23.tgz#2c508f64b3bb5862abc71392a4b1696e2b8572d2"
+  integrity sha512-a1chSSjN323lnm3f4VWR/+6uyaXgTLII8PkiDeKkC3A+eauUswf/k09iBwDQGlkLg29mZ+zShWdm+YdH+sLY4w==
+
+intl-messageformat-parser@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-4.1.1.tgz#33a3ac1854a8b9adc18dfc73db018abf91be4c32"
+  integrity sha512-RDmhjncV9VOKZ5nkoeeTxVy6G2kV5ZZNtewT89vj7vkr5NAPjw8/q6xYjUxdLnxNbQPcwno6zTD6j9VC0PW+Ag==
+  dependencies:
+    "@formatjs/intl-unified-numberformat" "^3.3.0"
+
+intl-messageformat@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-8.3.2.tgz#ad6b06982d749d39b6610ad26e88637d64688972"
+  integrity sha512-CMcGPciQjt1nesTME7vekUgx+Igy2sa14g/BZE2ZrYwqkdnVDO5f0bt3X0ZjQJohgZth9RvlIMvVoRUjrDRubA==
+  dependencies:
+    intl-format-cache "^4.2.22"
+    intl-messageformat-parser "^4.1.1"
+
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+  integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
 
 invariant@^2.2.4:
   version "2.2.4"
@@ -5486,7 +5564,25 @@ react-devtools-core@^4.0.6:
     shell-quote "^1.6.1"
     ws "^7"
 
-react-is@^16.12.0, react-is@^16.13.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-intl@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-4.3.1.tgz#a56ae90aa76bf8cac992606002dc8cbf1276ed7d"
+  integrity sha512-WaF6h1H9b4//csBTZ9JGfrKrceOCIKBjJZMBB0P/E+mjjkR1BJjytH2SEBbPV2bnDDnN6vQQaFz5MhgPfUDMYw==
+  dependencies:
+    "@formatjs/intl-displaynames" "^1.2.2"
+    "@formatjs/intl-listformat" "^1.4.2"
+    "@formatjs/intl-relativetimeformat" "^4.5.10"
+    "@formatjs/intl-unified-numberformat" "^3.3.0"
+    "@formatjs/intl-utils" "^2.2.0"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/invariant" "^2.2.31"
+    hoist-non-react-statics "^3.3.2"
+    intl-format-cache "^4.2.22"
+    intl-messageformat "^8.3.2"
+    intl-messageformat-parser "^4.1.1"
+    shallow-equal "^1.2.1"
+
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -5516,6 +5612,11 @@ react-native-iphone-x-helper@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
   integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
+
+react-native-localize@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-1.3.4.tgz#7d5c7b7ea30548d777a641457434d363cfac48db"
+  integrity sha512-ZVdapfTIcizCQ6nfbkTzjN/+D1eFb3aRtmOSC6d4LtjYRovUnv0QmNSg35CI/Q8Jy3nx4bHg6M9QyQ75MHzf7Q==
 
 react-native-reanimated@^1.7.1:
   version "1.7.1"
@@ -6011,6 +6112,11 @@ setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
+shallow-equal@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
+  integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Trello ticket:
https://trello.com/c/x46zeuAe/11-plan-architect-multilingual-support

@SamRichards  - please create multiple virtual devices for different language testing as per the screenshot below. Then go into Android settings for each - add the relevant language and delete the default US english. 
<img width="1373" alt="Screenshot 2020-04-02 at 15 09 47" src="https://user-images.githubusercontent.com/449406/78259025-04d2fd80-74f4-11ea-81d4-d9f2483048fc.png">

You should then find when you then run the app in the different emulators that you see the different string files in the translated screen:

<img width="647" alt="Screenshot 2020-04-02 at 15 04 39" src="https://user-images.githubusercontent.com/449406/78258891-cd645100-74f3-11ea-9dcd-69fb99074a14.png">

<img width="647" alt="Screenshot 2020-04-02 at 15 02 36" src="https://user-images.githubusercontent.com/449406/78258910-d523f580-74f3-11ea-83d6-f3461b8b783c.png">

<img width="647" alt="Screenshot 2020-04-02 at 15 06 11" src="https://user-images.githubusercontent.com/449406/78258921-dc4b0380-74f3-11ea-9250-fbc059e95f38.png">

<img width="647" alt="Screenshot 2020-04-02 at 15 06 42" src="https://user-images.githubusercontent.com/449406/78258935-e3721180-74f3-11ea-9f1d-1dc95529f8ff.png">
