### PR TITLE
Type configuration - fixing minor bugs

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -64,6 +64,7 @@ interface ButtonIconProps {
 export const ButtonIcon = (props: ButtonIconProps) => {
   return (
     <TouchableOpacity
+      {...props}
       style={[
         {
           width: 44,
@@ -72,8 +73,7 @@ export const ButtonIcon = (props: ButtonIconProps) => {
           justifyContent: 'center',
         },
         props.style,
-      ]}
-      {...props}>
+      ]}>
       <Icon
         name="settings"
         size={props.iconSize ?? 24}

--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -11,6 +11,7 @@ interface Props extends TextProps {
 export const BodyText = (props: Props) => {
   return (
     <Text
+      {...props}
       style={[
         {
           fontSize: 16,
@@ -22,7 +23,6 @@ export const BodyText = (props: Props) => {
         },
         props.style,
       ]}
-      {...props}
     />
   )
 }
@@ -30,6 +30,7 @@ export const BodyText = (props: Props) => {
 export const BodyHeader = (props: Props) => {
   return (
     <Text
+      {...props}
       style={[
         {
           fontSize: 18,
@@ -41,7 +42,6 @@ export const BodyHeader = (props: Props) => {
         },
         props.style,
       ]}
-      {...props}
     />
   )
 }


### PR DESCRIPTION
Fixing a bug where properties where being overriden by the spread being at the bottom of the JSX element.

I found text elements with a `style` defined, would have all styles removed because the prop spread was incorrectly placed