### PR TITLE
hide scrollbar from scrollview

### DIFF
--- a/src/screens/ConsentScreen.tsx
+++ b/src/screens/ConsentScreen.tsx
@@ -30,7 +30,7 @@ function Consent({navigation}: Props) {
           containerStyles.centeredContent,
           {margin: 24},
         ]}>
-        <ScrollView>
+        <ScrollView showsVerticalScrollIndicator={false}>
           <BodyText style={{marginBottom: 24}}>
             <FormattedMessage id="consent.by-using-app" />
           </BodyText>


### PR DESCRIPTION
This PR adds the `showsVerticalScrollIndicator` prop to the `scrollview` component to hide the scrollbar