### PR TITLE
More elegant handling of 401 auto-logout

### DIFF
--- a/src/effects/use-previous.effect.ts
+++ b/src/effects/use-previous.effect.ts
@@ -1,0 +1,9 @@
+import {useEffect, useRef} from 'react'
+
+export const usePrevious = <T extends {}>(value: T): T | undefined => {
+  const ref = useRef<T>()
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}


### PR DESCRIPTION
It seems that the bearer token from the sandbox api expired when it's used to login to a second device. So I've written some code to make this clear to test users until it's rectified by the api guys.

<img width="647" alt="Screenshot 2020-04-24 at 15 53 59" src="https://user-images.githubusercontent.com/449406/80226562-6e05e680-8644-11ea-9b6f-e56494e1f73f.png">


<img width="540" alt="Screenshot 2020-04-24 at 15 56 09" src="https://user-images.githubusercontent.com/449406/80226580-74945e00-8644-11ea-8eed-1e4246cbb5d5.png">
