### PR TITLE
adjust styles for button shadows and add bottom blue border

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -93,10 +93,12 @@ export const ButtonIcon = (props: ButtonIconProps) => {
 
 const styles = StyleSheet.create({
   shadowStyles: {
-    shadowColor: 'rgba(0,0,0, 0.32)', // iOS box shadow
-    shadowOffset: {height: 1, width: 1}, // iOS box shadow
+    shadowColor: 'rgba(0, 0, 0, 0.2)', // iOS box shadow
+    shadowOffset: {height: 2, width: 0}, // iOS box shadow
     shadowOpacity: 1, // iOS box shadow
     shadowRadius: 1, // iOS box shadow
-    elevation: 2, // Android elevation,
+    elevation: 3, // Android elevation,
+    borderBottomColor: colors.blue4,
+    borderBottomWidth: 2,
   },
 })

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -5,7 +5,7 @@ const colors = {
   blue1: '#0C3966',
   blue2: '#0075EB',
   blue3: '#E0F0FF',
-  blue4: '#9dcbf9',
+  blue4: '#90ccfe',
   red1: '#FF3355',
   yellow1: '#FFC800',
   green1: '#00B849',


### PR DESCRIPTION
This PR adds the correct shadows to the button component, as well as the light blue border bottom to match the designs.

iOS:
<img width="369" alt="Screenshot 2020-05-04 at 14 32 29" src="https://user-images.githubusercontent.com/17218062/80973013-bb3d4180-8e16-11ea-875d-f80a892fed96.png">

Android:
<img width="313" alt="Screenshot 2020-05-04 at 14 32 35" src="https://user-images.githubusercontent.com/17218062/80973032-c1332280-8e16-11ea-83a8-6669d2f75874.png">

