### PR TITLE
bp entry backspace

### DIFF
--- a/src/screens/AddBpScreen.tsx
+++ b/src/screens/AddBpScreen.tsx
@@ -253,6 +253,9 @@ function AddBpScreen({navigation, route}: Props) {
                     diastolic.length === 0
                   ) {
                     systolicRef.current.focus()
+                    setSystolic(
+                      systolic.toString().substring(0, systolic.length - 1),
+                    )
                   }
                 }}
                 placeholder="0"


### PR DESCRIPTION
This PR makes it so that when you press backspace from the diastolic entry, the systolic value is backspaced correctly.