### PR TITLE
graph crash

### DIFF
--- a/src/components/bp-history-chart.tsx
+++ b/src/components/bp-history-chart.tsx
@@ -126,7 +126,13 @@ export const BpHistoryChart = ({bps}: Props) => {
           }}
           scale={{x: 'linear'}}
           theme={VictoryTheme.material}
-          containerComponent={<VictoryVoronoiContainer radius={30} />}>
+          containerComponent={
+            chartData.getScatterDataForGraph().length ? (
+              <VictoryVoronoiContainer radius={30} />
+            ) : (
+              <></>
+            )
+          }>
           <VictoryAxis
             tickCount={chartData.getAxisTickValues().length}
             tickFormat={(tick) => {

--- a/src/components/bs-history-chart.tsx
+++ b/src/components/bs-history-chart.tsx
@@ -203,7 +203,13 @@ export const BsHistoryChart = ({bloodSugarReadings, displayUnits}: Props) => {
           }}
           scale={{x: 'linear'}}
           theme={VictoryTheme.material}
-          containerComponent={<VictoryVoronoiContainer radius={30} />}>
+          containerComponent={
+            chartData.getScatterDataForGraph().length ? (
+              <VictoryVoronoiContainer radius={30} />
+            ) : (
+              <></>
+            )
+          }>
           <VictoryAxis
             tickCount={chartData.getAxisTickValues().length}
             tickFormat={(tick) => {


### PR DESCRIPTION
This PR only renders the graph container when data exists to populate the graph, stopping a crash that was occurring when data was deleted.