### PR TITLE
Fix/use best available language hook

### DIFF
--- a/hooks/useBestAvailableLanguage.ts
+++ b/hooks/useBestAvailableLanguage.ts
@@ -5,18 +5,18 @@ import {
 } from '../constants/languages'
 
 export default function useBestAvailableLanguage() {
-  const userLocals: string[] = []
-  const getUserLocals = getLocales()
-  getUserLocals.forEach((language) => {
-    userLocals.push(language.languageCode)
+  const userLocales = []
+  const getUserLocales = getLocales()
+  getUserLocales.forEach((language) => {
+    userLocales.push(language.languageCode)
   })
 
-  const matchingLocals = AVAILABLE_TRANSLATIONS.filter((local) => {
-    return userLocals.includes(local)
+  const matchingLocales = userLocales.filter((local) => {
+    return AVAILABLE_TRANSLATIONS.includes(local)
   })
 
-  if (matchingLocals[0]) {
-    return matchingLocals[0]
+  if (matchingLocales[0]) {
+    return matchingLocales[0]
   } else {
     return DEFAULT_LANGUAGE_CODE
   }


### PR DESCRIPTION
This commit fixes a bug where the user device languages were chosen in reverse order, so the BP-Passport app was applying the last language chosen in the device settings where it should be choosing the first for the app language. Some minor typos also fixed.